### PR TITLE
Fixed compatibility issues with python 3.8.X.

### DIFF
--- a/inkpca/incremental_kpca.py
+++ b/inkpca/incremental_kpca.py
@@ -79,7 +79,7 @@ class IncrKPCA(object):
         if self.nystrom:
             self.K_nm = kernel_matrix(X, kernel, range(n), cols)
 
-    def next(self):
+    def __next__(self):
         """
         Initiate the next iteration
 
@@ -104,9 +104,12 @@ class IncrKPCA(object):
         self.j += 1
 
         if rc:
-            return self.next()
+            return self.__next__()
         else:
             return out
+
+    def next(self):
+        return self.__next__()
 
     def update_K_nm(self):
         """

--- a/inkpca/kernels.py
+++ b/inkpca/kernels.py
@@ -19,7 +19,7 @@ def median_distance(X, n=1000):
     Median distance between pairs of a subset of data examples
 
     """
-    dist = np.zeros((n+1)*n/2)
+    dist = np.zeros((n+1)*n//2)
     for k, t in enumerate(combinations_with_replacement(range(n),2)):
         dist[k] = np.sqrt(np.sum(np.power(X[t[0],:] - X[t[1],:],2)))
     sigma = np.median(dist)


### PR DESCRIPTION
Employed fix for iterator compatibility between python 2 and 3, found [here](https://stackoverflow.com/questions/40923522/python-defining-an-iterator-class-failed-with-iter-returned-non-iterator-of). 

Also ensured correct integer division for both python 2 and 3.

Tested using experiments.py in python 2.7.18 and 3.8.5.